### PR TITLE
feat: add Dating tab with dating.json and Affection display

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bd2modmanager",
   "private": true,
-  "version": "4.2.0-beta",
+  "version": "4.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "BD2ModManager"
-version = "4.2.0-beta"
+version = "4.2.0"
 description = "Brown Dust 2 Mod Manager"
 authors = ["bruhnn"]
 edition = "2021"

--- a/src-tauri/data/dating.json
+++ b/src-tauri/data/dating.json
@@ -1,0 +1,191 @@
+{
+    "version": "0.0.1",
+    "dating": [
+        {
+            "dating_id": "1",
+            "costume_id": "003303",
+            "character": "Nebris",
+            "costume": "New Hire",
+            "affection": [
+                { "label": "1", "id": "28" },
+                { "label": "2-1", "id": "29" },
+                { "label": "2-2", "id": "30" },
+                { "label": "2-3", "id": "40" },
+                { "label": "3", "id": "31" },
+                { "label": "4", "id": "124" }
+            ]
+        },
+        {
+            "dating_id": "2",
+            "costume_id": "003402",
+            "character": "Morpeah",
+            "costume": "Daydream Bunny",
+            "affection": [
+                { "label": "1", "id": "33" },
+                { "label": "2", "id": "34" },
+                { "label": "3", "id": "35" },
+                { "label": "4", "id": "128" }
+            ]
+        },
+        {
+            "dating_id": "3",
+            "costume_id": "003203",
+            "character": "Loen",
+            "costume": "Celebrity Bunny",
+            "affection": [
+                { "label": "1", "id": "47" },
+                { "label": "2", "id": "48" }
+            ]
+        },
+        {
+            "dating_id": "4",
+            "costume_id": "001106",
+            "character": "Teresse",
+            "costume": "Medical Club",
+            "affection": [
+                { "label": "1", "id": "54" },
+                { "label": "2", "id": "56" },
+                { "label": "3", "id": "149" }
+            ]
+        },
+        {
+            "dating_id": "5",
+            "costume_id": "060802",
+            "character": "Elise",
+            "costume": "Code Name O",
+            "affection": [
+                { "label": "1", "id": "57" },
+                { "label": "2", "id": "58" },
+                { "label": "3", "id": "160" }
+            ]
+        },
+        {
+            "dating_id": "6",
+            "costume_id": "067603",
+            "character": "Wilhelmina",
+            "costume": "Water Park Queen",
+            "affection": [
+                { "label": "1", "id": "70" },
+                { "label": "2", "id": "71" },
+                { "label": "3", "id": "72" },
+                { "label": "4", "id": "206" }
+            ]
+        },
+        {
+            "dating_id": "7",
+            "costume_id": "000296",
+            "character": "Justia",
+            "costume": "Hot Summer Dream",
+            "affection": []
+        },
+        {
+            "dating_id": "8",
+            "costume_id": "001006",
+            "character": "Sylvia",
+            "costume": "Bikini Agent",
+            "affection": [
+                { "label": "1", "id": "91" },
+                { "label": "2", "id": "92" },
+                { "label": "3", "id": "93" }
+            ]
+        },
+        {
+            "dating_id": "9",
+            "costume_id": "001197",
+            "character": "Teresse",
+            "costume": "Milky Bikini",
+            "affection": []
+        },
+        {
+            "dating_id": "10",
+            "costume_id": "066403",
+            "character": "Angelica",
+            "costume": "Neon Savior",
+            "affection": [
+                { "label": "1", "id": "104" },
+                { "label": "2", "id": "106" }
+            ]
+        },
+        {
+            "dating_id": "11",
+            "costume_id": "000706",
+            "character": "Eclipse",
+            "costume": "Nightmare Bunny",
+            "affection": [
+                { "label": "1", "id": "112" },
+                { "label": "2", "id": "113" }
+            ]
+        },
+        {
+            "dating_id": "12",
+            "costume_id": "061492",
+            "character": "Zenith",
+            "costume": "Stranger Bunny",
+            "affection": []
+        },
+        {
+            "dating_id": "13",
+            "costume_id": "004102",
+            "character": "Tyr",
+            "costume": "Innocent Bunny",
+            "affection": [
+                { "label": "1", "id": "125" },
+                { "label": "2", "id": "126" }
+            ]
+        },
+        {
+            "dating_id": "14",
+            "costume_id": "003892",
+            "character": "Liberta",
+            "costume": "Hedonist",
+            "affection": []
+        },
+        {
+            "dating_id": "15",
+            "costume_id": "067004",
+            "character": "Ventana",
+            "costume": "Onsen Practitioner",
+            "affection": [
+                { "label": "1", "id": "136" },
+                { "label": "2", "id": "137" }
+            ]
+        },
+        {
+            "dating_id": "16",
+            "costume_id": "003604",
+            "character": "Olivier",
+            "costume": "Retired Legend",
+            "affection": [
+                { "label": "1", "id": "151" },
+                { "label": "2", "id": "152" }
+            ]
+        },
+        {
+            "dating_id": "17",
+            "costume_id": "004202",
+            "character": "Palette",
+            "costume": "Miracle Violet",
+            "affection": [
+                { "label": "1", "id": "182" },
+                { "label": "2", "id": "183" }
+            ]
+        },
+        {
+            "dating_id": "18",
+            "costume_id": "000396",
+            "character": "Scheherazade",
+            "costume": "Deliberate Ace",
+            "affection": []
+        },
+        {
+            "dating_id": "19",
+            "costume_id": "067104",
+            "character": "Granhildr",
+            "costume": "Combat Medic",
+            "affection": [
+                { "label": "1", "id": "223" },
+                { "label": "2", "id": "224" }
+            ]
+        }
+    ]
+}

--- a/src-tauri/src/commands/game.rs
+++ b/src-tauri/src/commands/game.rs
@@ -1,5 +1,5 @@
 use std::{fs, path::PathBuf};
-use bd2modmanager_lib::{game::{game::{self, VersionResult}, installer::{self, is_bdx_archive, is_bepinex_archive, is_configmanager_archive}}, utils::path::get_characters_path};
+use bd2modmanager_lib::{game::{game::{self, VersionResult}, installer::{self, is_bdx_archive, is_bepinex_archive, is_configmanager_archive}}, utils::path::{get_characters_path, get_dating_path}};
 use winreg::{enums::HKEY_CURRENT_USER, RegKey};
 use log::{info, warn};
 
@@ -55,6 +55,15 @@ pub fn get_characters(app_handle: tauri::AppHandle) -> Result<serde_json::Value,
     let chars_path = get_characters_path(&app_handle).ok_or("failed to get characters path")?;
 
     let content = std::fs::read_to_string(&chars_path).map_err(|e| e.to_string())?;
+
+    serde_json::from_str(&content).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn get_dating(app_handle: tauri::AppHandle) -> Result<serde_json::Value, String> {
+    let dating_path = get_dating_path(&app_handle).ok_or("failed to get dating path")?;
+
+    let content = std::fs::read_to_string(&dating_path).map_err(|e| e.to_string())?;
 
     serde_json::from_str(&content).map_err(|e| e.to_string())
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -315,6 +315,7 @@ pub fn main() {
             game::uninstall_configmanager,
             game::determine_archive_type,
             game::get_characters,
+            game::get_dating,
             // updater
             updater::get_mod_preview_version,
             updater::check_for_app_update,

--- a/src-tauri/src/utils/data.rs
+++ b/src-tauri/src/utils/data.rs
@@ -2,6 +2,7 @@ use std::fs;
 use tauri::Manager;
 
 const CHARACTERS: &str = include_str!("../../data/characters.json");
+const DATING: &str = include_str!("../../data/dating.json");
 
 pub fn move_data_to_appdata(app_handle: &tauri::AppHandle) -> Result<(), String> {
     let app_data = app_handle
@@ -11,39 +12,148 @@ pub fn move_data_to_appdata(app_handle: &tauri::AppHandle) -> Result<(), String>
 
     fs::create_dir_all(&app_data).map_err(|e| e.to_string())?;
 
-    let chars_path = app_data.join("characters.json");
+    seed_versioned_file(&app_data.join("characters.json"), CHARACTERS, "characters.json")?;
+    seed_versioned_file(&app_data.join("dating.json"), DATING, "dating.json")?;
 
-    if !chars_path.exists() {
-        println!("Seeding characters.json to appdata");
-        fs::write(&chars_path, CHARACTERS).map_err(|e| e.to_string())?;
-    } else {
-        let bundled_version = semver::Version::parse(
-            serde_json::from_str::<serde_json::Value>(CHARACTERS)
-                .map_err(|e| e.to_string())?["version"]
-                .as_str()
-                .ok_or("Missing 'version' in bundled characters.json")?,
-        )
-        .map_err(|e| e.to_string())?;
+    // Keep dating.json in sync with the dating map in characters.json: any
+    // dating_id present in characters.json but missing from dating.json gets a
+    // stub entry appended. Existing entries (and their manually-entered
+    // affection lists) are never modified.
+    sync_dating_from_characters(&app_data)?;
 
-        let existing_version = semver::Version::parse(
-            serde_json::from_str::<serde_json::Value>(
-                &fs::read_to_string(&chars_path).map_err(|e| e.to_string())?,
-            )
+    Ok(())
+}
+
+/// Seeds `bundled` into `path`, or overwrites it when the bundled version is
+/// newer. Both the bundled string and the existing file must carry a top-level
+/// semver `"version"` string.
+fn seed_versioned_file(path: &std::path::Path, bundled: &str, label: &str) -> Result<(), String> {
+    if !path.exists() {
+        println!("Seeding {label} to appdata");
+        fs::write(path, bundled).map_err(|e| e.to_string())?;
+        return Ok(());
+    }
+
+    let bundled_version = semver::Version::parse(
+        serde_json::from_str::<serde_json::Value>(bundled)
             .map_err(|e| e.to_string())?["version"]
-                .as_str()
-                .ok_or("Missing 'version' in existing characters.json")?,
+            .as_str()
+            .ok_or_else(|| format!("Missing 'version' in bundled {label}"))?,
+    )
+    .map_err(|e| e.to_string())?;
+
+    let existing_version = semver::Version::parse(
+        serde_json::from_str::<serde_json::Value>(
+            &fs::read_to_string(path).map_err(|e| e.to_string())?,
+        )
+        .map_err(|e| e.to_string())?["version"]
+            .as_str()
+            .ok_or_else(|| format!("Missing 'version' in existing {label}"))?,
+    )
+    .map_err(|e| e.to_string())?;
+
+    println!("{label} bundled v{bundled_version} vs appdata v{existing_version}");
+
+    if bundled_version > existing_version {
+        println!("Updating {label} from bundled (newer version)");
+        fs::write(path, bundled).map_err(|e| e.to_string())?;
+    }
+
+    Ok(())
+}
+
+/// Appends stub dating entries for any dating_id found in characters.json's
+/// `dating` map that is not already present in dating.json. Manual edits to
+/// existing entries (including affection lists) are preserved.
+fn sync_dating_from_characters(app_data: &std::path::Path) -> Result<(), String> {
+    let chars_path = app_data.join("characters.json");
+    let dating_path = app_data.join("dating.json");
+
+    let chars: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(&chars_path).map_err(|e| e.to_string())?,
+    )
+    .map_err(|e| e.to_string())?;
+
+    let mut dating: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(&dating_path).map_err(|e| e.to_string())?,
+    )
+    .map_err(|e| e.to_string())?;
+
+    // dating map: { "<dating_id>": "<costume_id>", ... }
+    let dating_map = match chars.get("dating").and_then(|v| v.as_object()) {
+        Some(m) => m,
+        None => return Ok(()),
+    };
+
+    // Build a lookup of costume_id -> character entry so stubs can be labelled.
+    let characters = chars
+        .get("characters")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+
+    let find_costume = |costume_id: &str| -> Option<(String, String)> {
+        for c in &characters {
+            // id may be a string or an array of strings.
+            let matches = match c.get("id") {
+                Some(serde_json::Value::String(s)) => s == costume_id,
+                Some(serde_json::Value::Array(arr)) => {
+                    arr.iter().any(|v| v.as_str() == Some(costume_id))
+                }
+                _ => false,
+            };
+            if matches {
+                let character = c
+                    .get("character")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let costume = c
+                    .get("costume")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                return Some((character, costume));
+            }
+        }
+        None
+    };
+
+    let entries = match dating.get_mut("dating").and_then(|v| v.as_array_mut()) {
+        Some(e) => e,
+        None => return Ok(()),
+    };
+
+    let existing_ids: std::collections::HashSet<String> = entries
+        .iter()
+        .filter_map(|e| e.get("dating_id").and_then(|v| v.as_str()).map(String::from))
+        .collect();
+
+    let mut appended = 0;
+    for (dating_id, costume_id_val) in dating_map {
+        if existing_ids.contains(dating_id) {
+            continue;
+        }
+        let costume_id = costume_id_val.as_str().unwrap_or("").to_string();
+        let (character, costume) = find_costume(&costume_id).unwrap_or_default();
+
+        entries.push(serde_json::json!({
+            "dating_id": dating_id,
+            "costume_id": costume_id,
+            "character": character,
+            "costume": costume,
+            "affection": []
+        }));
+        appended += 1;
+    }
+
+    if appended > 0 {
+        println!("dating.json: appended {appended} new stub entr(y/ies) from characters.json");
+        fs::write(
+            &dating_path,
+            serde_json::to_string_pretty(&dating).map_err(|e| e.to_string())?,
         )
         .map_err(|e| e.to_string())?;
-
-        println!(
-            "characters.json bundled v{} vs appdata v{}",
-            bundled_version, existing_version
-        );
-
-        if bundled_version > existing_version {
-            println!("Updating characters.json from bundled (newer version)");
-            fs::write(&chars_path, CHARACTERS).map_err(|e| e.to_string())?;
-        }
     }
 
     Ok(())

--- a/src-tauri/src/utils/path.rs
+++ b/src-tauri/src/utils/path.rs
@@ -69,3 +69,11 @@ pub fn get_characters_path(app_handle: &AppHandle) -> Option<PathBuf> {
     .ok()
     .map(|dir| dir.join("characters.json"))
 }
+
+pub fn get_dating_path(app_handle: &AppHandle) -> Option<PathBuf> {
+    app_handle
+    .path()
+    .app_data_dir()
+    .ok()
+    .map(|dir| dir.join("dating.json"))
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "BD2ModManager",
-  "version": "4.2.0-beta",
+  "version": "4.2.0",
   "identifier": "com.bruhnn.BD2ModManager",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/components/sidebar/NavigationButton.vue
+++ b/src/components/sidebar/NavigationButton.vue
@@ -3,7 +3,8 @@ import { computed } from 'vue';
 import router from '../../router';
 
 const props = defineProps<{
-    icon: any
+    icon?: any
+    iconSrc?: string
     label: string
     value: string
 }>()
@@ -27,7 +28,8 @@ const active = computed(() => {
         flex items-center 
         text-sm font-medium
         hover:bg-state-hover hover:text-text-primary">
-        <component :is="icon" class="w-[1.75em] h-[1.75em] text-text-primary transition-colors duration-200" :class="{'text-text-on-accent!': active}" />
+        <img v-if="iconSrc" :src="iconSrc" class="w-[1.75em] h-[1.75em] object-contain" />
+        <component v-else :is="icon" class="w-[1.75em] h-[1.75em] text-text-primary transition-colors duration-200" :class="{'text-text-on-accent!': active}" />
         {{ label }}
         
     </RouterLink>

--- a/src/components/sidebar/Sidebar.vue
+++ b/src/components/sidebar/Sidebar.vue
@@ -83,6 +83,7 @@ function onProfileSelected(profile_id: string) {
             <NavigationSection :title="$t('sidebar.sections.navigation')">
                 <NavigationButton :icon="Component" :label="$t('sidebar.tabs.mods')" value="mods" />
                 <NavigationButton :icon="Users" :label="$t('sidebar.tabs.characters')" value="characters" />
+                <NavigationButton icon-src="/icons/dating.png" :label="$t('sidebar.tabs.dating')" value="dating" />
             </NavigationSection>
             <NavigationSection :title="$t('sidebar.sections.settings')">
                 <NavigationButton :icon="Bolt" :label="$t('sidebar.tabs.profiles')" value="profiles" />

--- a/src/composables/useAppInit.ts
+++ b/src/composables/useAppInit.ts
@@ -38,6 +38,7 @@ export function useAppInitializer() {
     await Promise.all([
       settingsStore.loadSettings(),
       useCharactersStore().loadCharacters(),
+      useCharactersStore().loadDating(),
       useProfilesStore().loadProfiles(),
     ]);
 

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -82,7 +82,8 @@
             "characters": "Characters",
             "profiles": "Profiles",
             "browndustx": "BrownDustX",
-            "settings": "Settings"
+            "settings": "Settings",
+            "dating": "Dating"
         },
         "notifications": {
             "gameLaunched": {
@@ -874,5 +875,37 @@
         "shouldBeInFolder": "This mod should be inside a folder. Please create a folder with the same name as the mod and move the mod file inside it.",
         "missingAtlasFile": "This mod is missing the atlas file.",
         "noDescription": "No description provided."
+    },
+    "datingTab": {
+        "title": "Dating",
+        "subtitle": "{enabledModsCount} of {totalModsCount} dating mods enabled",
+        "charactersNotFound": "No characters with dating mods found.",
+        "filters": {
+            "title": "Filters",
+            "searchPlaceholder": "Search characters...",
+            "sortBy": {
+                "title": "Sort By",
+                "options": {
+                    "nameAsc": "Name (A-Z)",
+                    "nameDesc": "Name (Z-A)",
+                    "modsAsc": "Number of Mods (Fewest)",
+                    "modsDesc": "Number of Mods (Most)"
+                }
+            },
+            "modStatus": {
+                "title": "Mod Status",
+                "hasDating": "Has Dating Mod",
+                "options": {
+                    "any": "Any",
+                    "enabled": "Enabled",
+                    "disabled": "Disabled"
+                }
+            }
+        },
+        "affection": {
+            "title": "Affection",
+            "label": "Affection {label}",
+            "notInstalled": "Not installed"
+        }
     }
 }

--- a/src/pages/dating/DatingGrid.vue
+++ b/src/pages/dating/DatingGrid.vue
@@ -1,0 +1,103 @@
+<script setup lang="ts">
+import { computed, ref, watch, ComponentPublicInstance } from 'vue';
+import { useVirtualizer } from '@tanstack/vue-virtual';
+import { useResizeObserver } from '@vueuse/core';
+import { Character } from '../../stores/characters';
+import DatingGridItem from './DatingGridItem.vue';
+import { useSaveScroll } from '../../composables/useSaveScroll';
+
+export interface DatingCostume extends Character {
+    hasDating?: boolean;
+    modsCount: number;
+    affectionEnabled?: number;
+    affectionTotal?: number;
+    hasAffection?: boolean;
+}
+
+const props = defineProps<{ items: DatingCostume[] }>();
+defineEmits<{ 'open-mod-details': [costume: Character] }>();
+
+const parentRef = ref<HTMLElement | null>(null);
+const columnCount = ref(4);
+
+function getColumnCount(width: number) {
+    if (width >= 940) return 5;
+    if (width >= 740) return 4;
+    if (width >= 480) return 3;
+    if (width >= 440) return 2;
+    return 1;
+}
+
+useResizeObserver(parentRef, ([entry]) => {
+    columnCount.value = getColumnCount(entry.contentRect.width);
+});
+
+const rows = computed(() => {
+    const result: DatingCostume[][] = [];
+    for (let i = 0; i < props.items.length; i += columnCount.value) {
+        result.push(props.items.slice(i, i + columnCount.value));
+    }
+    return result;
+});
+
+const rowVirtualizer = useVirtualizer({
+    get count() { return rows.value.length; },
+    getScrollElement: () => parentRef.value,
+    estimateSize: () => 340,
+    overscan: 4,
+    measureElement: (element, _entry, instance) => {
+        const index = Number(element.getAttribute('data-index'));
+        const cached = instance.measurementsCache[index]?.size;
+        if (cached !== undefined) return cached;
+        return element.getBoundingClientRect().height;
+    },
+});
+
+watch(columnCount, () => {
+    rowVirtualizer.value.measure();
+});
+
+const virtualRows = computed(() => rowVirtualizer.value.getVirtualItems());
+const totalSize = computed(() => rowVirtualizer.value.getTotalSize());
+
+const measureElement = (el: Element | ComponentPublicInstance | null) => {
+    if (!el || !(el instanceof Element)) return;
+    rowVirtualizer.value.measureElement(el);
+};
+
+useSaveScroll(rowVirtualizer)
+</script>
+
+<template>
+    <div v-if="items.length === 0" class="text-center py-12 text-text-secondary">
+        <p class="text-lg">{{ $t('datingTab.charactersNotFound') }}</p>
+    </div>
+
+    <div v-else ref="parentRef" class="h-full overflow-y-auto bg-surface-app" style="contain: strict">
+        <div :style="{ height: `${totalSize}px`, width: '100%', position: 'relative' }">
+            <div :style="{
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                width: '100%',
+                transform: `translateY(${virtualRows[0]?.start ?? 0}px)`,
+            }">
+                <div
+                    v-for="virtualRow in virtualRows"
+                    :key="String(virtualRow.key)"
+                    :ref="measureElement"
+                    :data-index="virtualRow.index"
+                    class="grid gap-4 pb-4"
+                    :style="{ gridTemplateColumns: `repeat(${columnCount}, minmax(0, 1fr))` }"
+                >
+                    <DatingGridItem
+                        v-for="costume in rows[virtualRow.index]"
+                        :key="Array.isArray(costume.id) ? costume.id.join('-') : costume.id as string"
+                        :costume="costume"
+                        @open-mod-details="$emit('open-mod-details', costume)"
+                    />
+                </div>
+            </div>
+        </div>
+    </div>
+</template>

--- a/src/pages/dating/DatingGridItem.vue
+++ b/src/pages/dating/DatingGridItem.vue
@@ -1,0 +1,90 @@
+<script setup lang="ts">
+import { convertFileSrc } from '@tauri-apps/api/core'
+import { isCostumeNew } from '../../stores/characters'
+import { Check, X } from 'lucide-vue-next'
+import { computed } from 'vue'
+import Image from '../../components/common/Image.vue'
+import { formatCharName, useLang } from '../../utils/formatCharName.ts'
+import type { DatingCostume } from './DatingGrid.vue'
+
+const props = defineProps<{
+    costume: DatingCostume
+}>()
+
+const imageUrl = computed(() => {
+    const ids = Array.isArray(props.costume.id)
+        ? props.costume.id.join(',')
+        : props.costume.id
+    return convertFileSrc(`standing/${ids}`, "bd2assets")
+})
+
+const lang = useLang()
+
+const charName = computed(() => {
+    return formatCharName(props.costume, lang.value)
+})
+</script>
+
+<template>
+    <div @click="$emit('open-mod-details', costume)"
+        class="rounded-lg cursor-pointer transition-all bg-surface-card text-text-primary hover:bg-state-hover flex flex-col h-full overflow-hidden">
+        <div class="relative">
+            <Image :src="imageUrl" :alt="charName" class="w-full aspect-square rounded-t-md"
+                error-src="characters/standing/placeholder_character.png" skeleton error-class="bg-text-primary" />
+            <div class="absolute top-2.5 left-2.5 flex gap-1">
+                <div v-if="costume.modsCount > 0"
+                    class="bg-accent/75 text-text-on-accent text-xs px-2 py-1 rounded-full font-medium">
+                    {{ $t('charactersTab.tags.modsCount', { count: costume.modsCount }) }}
+                </div>
+                <div v-if="costume.is_collab"
+                    class="bg-warning-bg text-warning text-xs px-2 py-1 rounded-full font-medium">
+                    {{ $t('charactersTab.tags.collab') }}
+                </div>
+            </div>
+        </div>
+
+        <div class="px-2 py-2 flex flex-col shrink-0">
+            <div class="mb-2">
+                <div class="font-semibold text-sm min-w-0 flex gap-2 items-center" :title="charName">
+                    <div v-if="isCostumeNew(costume)"
+                        class="bg-error-bg text-error text-xs px-2 py-0.5 rounded-sm font-medium shrink-0">
+                        {{ $t('charactersTab.tags.new') }}
+                    </div>
+                    <span class="truncate">
+                        {{ charName }}
+                    </span>
+                </div>
+            </div>
+
+            <!-- Dating indicator, plus an Affection count when the character has
+                 affection entries defined in dating.json. -->
+            <div
+                class="flex justify-around items-center gap-2 text-xs text-text-primary font-mono overflow-x-auto scrollbar-hide">
+                <div class="text-center p-1">
+                    <div class="mb-1 flex items-center font-bold gap-1">
+                        {{ $t('charactersTab.modTypes.dating') }}
+                    </div>
+                    <div class="flex justify-center"
+                        :class="costume.hasDating ? 'text-success font-bold' : 'text-error'">
+                        <Check class="w-[1.25em] h-[1.25em]" v-if="costume.hasDating" />
+                        <X class="w-[1.25em] h-[1.25em]" v-else />
+                    </div>
+                </div>
+                <div v-if="(costume.affectionTotal ?? 0) > 0" class="text-center p-1">
+                    <div class="mb-1 flex items-center font-bold gap-1">
+                        {{ $t('datingTab.affection.title') }}
+                    </div>
+                    <div class="flex justify-center font-bold" :class="{
+                        'text-success': costume.affectionEnabled === costume.affectionTotal,
+                        'text-warning': (costume.affectionEnabled ?? 0) > 0 && costume.affectionEnabled !== costume.affectionTotal,
+                        'text-error': (costume.affectionEnabled ?? 0) === 0
+                    }">
+                        {{ costume.affectionEnabled }}/{{ costume.affectionTotal }}
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</template>
+
+<style></style>

--- a/src/pages/dating/DatingTab.vue
+++ b/src/pages/dating/DatingTab.vue
@@ -1,0 +1,323 @@
+<script setup lang="ts">
+import { Grid3X3, List, RefreshCcw } from 'lucide-vue-next';
+import { computed, reactive, ref, onActivated, onDeactivated } from 'vue';
+import { useLocalStorage } from '@vueuse/core';
+import { useI18n } from 'vue-i18n';
+
+import { Character, useCharactersStore } from '../../stores/characters';
+import { BD2Mod, useModsStore } from '../../stores/mods';
+
+import { useHeader } from '../../composables/useHeader';
+
+import DatingGrid from './DatingGrid.vue';
+import DatingModal from './modals/DatingModal.vue';
+import Button from '../../components/common/Button.vue';
+import Input from '../../components/common/Input.vue';
+import Select from '../../components/common/Select.vue';
+import Image from '../../components/common/Image.vue';
+import { convertFileSrc } from '@tauri-apps/api/core';
+import { formatCharName, useLang } from '../../utils/formatCharName';
+import type { DatingCostume } from './DatingGrid.vue';
+
+const { t } = useI18n();
+const charactersStore = useCharactersStore();
+const modsStore = useModsStore();
+
+const viewMode = useLocalStorage('dating-view-mode', 'grid'); // 'grid' or 'list'
+const lang = useLang();
+
+const userFilters = reactive({
+    searchQuery: '',
+    sortBy: 'a-z',
+    dating: 'any'
+});
+
+const sortOptions = computed(() => [
+    { label: t('charactersTab.filters.sortBy.options.nameAsc'), value: 'a-z' },
+    { label: t('charactersTab.filters.sortBy.options.nameDesc'), value: 'z-a' },
+    { label: t('charactersTab.filters.sortBy.options.releaseAsc'), value: 'newest' },
+    { label: t('charactersTab.filters.sortBy.options.releaseDesc'), value: 'oldest' },
+    { label: t('charactersTab.filters.sortBy.options.modsDesc'), value: 'mods-desc' },
+    { label: t('charactersTab.filters.sortBy.options.modsAsc'), value: 'mods-asc' },
+]);
+
+const modStatusOptions = computed(() => [
+    { label: t('charactersTab.filters.modStatus.options.any'), value: 'any' },
+    { label: t('charactersTab.filters.modStatus.options.enabled'), value: 'enabled' },
+    { label: t('charactersTab.filters.modStatus.options.disabled'), value: 'disabled' }
+]);
+
+// Index dating mods by the character id they resolve to (via dating_id).
+const datingIndex = computed(() => {
+    type Mod = typeof modsStore.mods[number];
+    const index = new Map<string, { enabled: boolean; mods: Mod[] }>();
+
+    for (const mod of modsStore.mods) {
+        if (!mod.modType || mod.modType.type !== 'Dating' || !('id' in mod.modType)) continue;
+
+        const characterId = charactersStore.getCharacterIdByDatingId(mod.modType.id);
+        if (!characterId) continue;
+
+        let entry = index.get(characterId);
+        if (!entry) {
+            entry = { enabled: false, mods: [] };
+            index.set(characterId, entry);
+        }
+        entry.mods.push(mod);
+        if (mod.enabled) entry.enabled = true;
+    }
+
+    return index;
+});
+
+function idList(id: string | readonly string[]) {
+    return Array.isArray(id) ? id : [id as string];
+}
+
+// Index installed Scene-typed mods (affection mods use the "specialillust"
+// prefix, which the Rust classifier maps to the Scene type). Keyed by the
+// Scene mod id, which matches an AffectionEntry.id in dating.json.
+const affectionModIndex = computed(() => {
+    const present = new Set<string>();
+    const enabled = new Set<string>();
+    for (const mod of modsStore.mods) {
+        if (!mod.modType || mod.modType.type !== 'Scene' || !('id' in mod.modType)) continue;
+        present.add(mod.modType.id);
+        if (mod.enabled && !mod.errors.length) enabled.add(mod.modType.id);
+    }
+    return { present, enabled };
+});
+
+// Per-character affection status resolved via the labelled affection list from
+// dating.json (keyed by dating_id).
+function getAffectionStatus(char: Character) {
+    if (!char.dating_id) return { total: 0, enabled: 0, hasAffection: false };
+    const affection = charactersStore.getAffection(char.dating_id);
+    const total = affection.length;
+    const enabled = affection.filter(a => affectionModIndex.value.enabled.has(a.id)).length;
+    return { total, enabled, hasAffection: enabled > 0 };
+}
+
+function hasDatingInstalled(id: string | readonly string[]) {
+    return idList(id).some(i => datingIndex.value.get(i)?.enabled);
+}
+
+function getInstalledMods(id: string | readonly string[]) {
+    return idList(id).flatMap(i => datingIndex.value.get(i)?.mods ?? []);
+}
+
+function getInstalledModsCount(id: string | readonly string[]) {
+    return idList(id).reduce((sum, i) => sum + (datingIndex.value.get(i)?.mods.length ?? 0), 0);
+}
+
+// All characters that have a dating_id — shown even when no dating mods are
+// installed, so the tab is never empty just because the user lacks mods.
+const datingCharacters = computed(() => {
+    return charactersStore.characters.filter(char => !!char.dating_id);
+});
+
+const totalModsCount = computed(() =>
+    datingCharacters.value.reduce((sum, c) => sum + getInstalledModsCount(c.id), 0)
+);
+const enabledModsCount = computed(() =>
+    datingCharacters.value.reduce((sum, c) =>
+        sum + getInstalledMods(c.id).filter(m => m.enabled && !m.errors.length).length, 0)
+);
+
+const filteredCharacters = computed(() => {
+    const search = userFilters.searchQuery.toLowerCase();
+    return datingCharacters.value.filter(char => {
+        if (search &&
+            !char.character.toLowerCase().includes(search) &&
+            !char.costume.toLowerCase().includes(search)
+        ) return false;
+
+        const enabled = hasDatingInstalled(char.id);
+        if (userFilters.dating === 'enabled' && !enabled) return false;
+        if (userFilters.dating === 'disabled' && enabled) return false;
+
+        return true;
+    });
+});
+
+const sortedCharacters = computed(() => {
+    const arr = [...filteredCharacters.value];
+    arr.sort((a, b) => {
+        switch (userFilters.sortBy) {
+            case 'a-z':
+                return a.character.localeCompare(b.character) || a.costume.localeCompare(b.costume);
+            case 'z-a':
+                return b.character.localeCompare(a.character) || b.costume.localeCompare(a.costume);
+            case 'newest':
+                return new Date(b.release_date || 0).getTime() - new Date(a.release_date || 0).getTime();
+            case 'oldest':
+                return new Date(a.release_date || 0).getTime() - new Date(b.release_date || 0).getTime();
+            case 'mods-desc':
+                return getInstalledModsCount(b.id) - getInstalledModsCount(a.id);
+            case 'mods-asc':
+                return getInstalledModsCount(a.id) - getInstalledModsCount(b.id);
+            default:
+                return 0;
+        }
+    });
+    return arr;
+});
+
+const datingGrid = computed<DatingCostume[]>(() =>
+    sortedCharacters.value.map(costume => {
+        const aff = getAffectionStatus(costume);
+        return {
+            ...costume,
+            hasDating: hasDatingInstalled(costume.id),
+            modsCount: getInstalledModsCount(costume.id),
+            affectionEnabled: aff.enabled,
+            affectionTotal: aff.total,
+            hasAffection: aff.hasAffection
+        };
+    })
+);
+
+function listImageUrl(costume: Character) {
+    const ids = Array.isArray(costume.id) ? costume.id.join(',') : costume.id;
+    return convertFileSrc(`standing/${ids}`, 'bd2assets');
+}
+
+const showModal = ref(false);
+const selectedCostume = ref<Character | null>(null);
+
+function openModDetails(costume: Character) {
+    selectedCostume.value = costume;
+    showModal.value = true;
+}
+
+function toggleMod(mod: BD2Mod) {
+    if (mod.enabled) {
+        modsStore.disableMods([mod.name]);
+    } else {
+        modsStore.enableMods([mod.name]);
+    }
+}
+
+function refreshData() {
+    charactersStore.loadCharacters();
+    charactersStore.loadDating();
+    modsStore.discoverMods();
+}
+
+const scrollTop = ref(0);
+const scrollContainer = ref<HTMLElement | null>(null);
+
+onDeactivated(() => {
+    if (scrollContainer.value) scrollTop.value = scrollContainer.value.scrollTop;
+});
+onActivated(() => {
+    if (scrollContainer.value) scrollContainer.value.scrollTop = scrollTop.value;
+});
+
+useHeader({
+    title: t('datingTab.title'),
+    subtitle: computed(() =>
+        t('datingTab.subtitle', {
+            enabledModsCount: enabledModsCount.value,
+            totalModsCount: totalModsCount.value
+        })
+    ),
+    buttons: [
+        { icon: RefreshCcw, label: t('common.actions.refreshMods'), action: refreshData },
+    ]
+});
+</script>
+
+<template>
+    <div class="flex flex-row w-full h-full p-4 py-2 gap-4 bg-surface-app overflow-hidden">
+        <div class="flex-1 min-h-0 overflow-hidden">
+            <div v-if="datingGrid.length === 0" class="text-center py-12 text-text-secondary">
+                <p class="text-lg">{{ t('datingTab.charactersNotFound') }}</p>
+            </div>
+
+            <DatingGrid v-else-if="viewMode === 'grid'" :items="datingGrid" @open-mod-details="openModDetails" />
+
+            <!-- List view -->
+            <div v-else ref="scrollContainer" class="h-full overflow-y-auto bg-surface-app">
+                <div v-for="costume in datingGrid"
+                    :key="Array.isArray(costume.id) ? costume.id.join('-') : (costume.id as string)"
+                    @click="openModDetails(costume)"
+                    class="flex bg-surface-card rounded-lg overflow-hidden cursor-pointer hover:bg-state-hover transition-colors mx-2 mb-2">
+                    <div class="shrink-0">
+                        <Image :src="listImageUrl(costume)" class="w-42 h-42 object-cover object-top rounded-t-md aspect-square"
+                            error-src="characters/standing/placeholder_character.png" error-class="bg-text-primary" skeleton />
+                    </div>
+                    <div class="flex flex-col flex-1 p-2 min-w-0">
+                        <div class="text-lg font-medium flex gap-2 items-center flex-wrap">
+                            <span class="truncate">{{ formatCharName(costume, lang) }}</span>
+                            <div v-if="costume.modsCount > 0"
+                                class="flex bg-accent/75 text-text-on-accent text-xs px-2 py-1 rounded-full font-medium whitespace-nowrap">
+                                {{ t('charactersTab.tags.modsCount', { count: costume.modsCount }) }}
+                            </div>
+                        </div>
+                        <div class="flex flex-1 items-end gap-8 md:gap-12 mr-4 md:mr-8 mt-2">
+                            <div class="flex flex-col items-center">
+                                <span class="font-semibold text-sm md:text-base">{{ t('charactersTab.modTypes.dating') }}</span>
+                                <span class="font-mono text-xs md:text-sm" :class="{
+                                    'text-success': costume.hasDating,
+                                    'text-error': !costume.hasDating
+                                }">
+                                    {{ costume.hasDating ? t('charactersTab.modTypes.states.enabled', 'Enabled') : t('charactersTab.modTypes.states.disabled', 'Disabled') }}
+                                </span>
+                            </div>
+                            <div v-if="(costume.affectionTotal ?? 0) > 0" class="flex flex-col items-center">
+                                <span class="font-semibold text-sm md:text-base">{{ t('datingTab.affection.title') }}</span>
+                                <span class="font-mono text-xs md:text-sm" :class="{
+                                    'text-success': costume.affectionEnabled === costume.affectionTotal,
+                                    'text-warning': (costume.affectionEnabled ?? 0) > 0 && costume.affectionEnabled !== costume.affectionTotal,
+                                    'text-error': (costume.affectionEnabled ?? 0) === 0
+                                }">
+                                    {{ costume.affectionEnabled }}/{{ costume.affectionTotal }}
+                                </span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div
+            class="flex overflow-y-auto flex-col gap-2.5 items-start justify-start w-full max-w-[20%] min-w-50 p-2 bg-surface-panel rounded-md border border-border-default">
+            <h1 class="text-lg font-bold text-text-primary flex flex-row justify-between items-center w-full">
+                {{ t('charactersTab.filters.title') }}
+                <div class="flex gap-1">
+                    <Button @click="viewMode = 'grid'" :icon="Grid3X3" :icon-class="{
+                        'text-accent': viewMode === 'grid',
+                        'text-text-primary': viewMode !== 'grid',
+                        'text-xs': true
+                    }" />
+                    <Button @click="viewMode = 'list'" :icon="List" :icon-class="{
+                        'text-accent': viewMode === 'list',
+                        'text-text-primary': viewMode !== 'list',
+                        'text-xs': true
+                    }" />
+                </div>
+            </h1>
+
+            <div class="flex flex-col gap-4 w-full">
+                <div class="min-h-10 w-full">
+                    <Input v-model="userFilters.searchQuery" :placeholder="t('charactersTab.filters.searchPlaceholder')" class="w-64" />
+                </div>
+
+                <div class="flex flex-col gap-1.5">
+                    <label class="text-sm font-semibold text-text-primary">{{ t('charactersTab.filters.sortBy.title') }}</label>
+                    <Select v-model="userFilters.sortBy" :options="sortOptions" />
+                </div>
+
+                <div class="flex flex-col gap-1.5">
+                    <label class="text-sm font-semibold text-text-primary">{{ t('charactersTab.filters.modStatus.hasDating') }}</label>
+                    <Select v-model="userFilters.dating" :options="modStatusOptions" />
+                </div>
+            </div>
+        </div>
+
+        <DatingModal v-model:show="showModal" :selectedCostume="selectedCostume" :toggleMod="toggleMod" />
+    </div>
+</template>
+
+<style scoped></style>

--- a/src/pages/dating/modals/DatingModal.vue
+++ b/src/pages/dating/modals/DatingModal.vue
@@ -1,0 +1,229 @@
+<script setup lang="ts">
+import { X, Calendar, Eye, Tag } from 'lucide-vue-next';
+import { Character, useCharactersStore } from '../../../stores/characters';
+import { BD2Mod, useModsStore } from '../../../stores/mods';
+import { computed } from 'vue';
+import Button from '../../../components/common/Button.vue';
+import Image from '../../../components/common/Image.vue';
+import Modal from '../../../components/common/Modal.vue';
+import Checkbox from '../../../components/common/Checkbox.vue';
+import { useLoggingStore } from '../../../stores/logging';
+import { getErrorMessage } from '../../../utils/errors';
+import { useI18n } from 'vue-i18n';
+import { convertFileSrc } from '@tauri-apps/api/core';
+import { useNotificationStore } from '../../../stores/notification.ts';
+import { getCharName, useLang } from '../../../utils/formatCharName.ts';
+import { sortModsByPath } from '../../../utils/sortMods';
+
+const loggingStore = useLoggingStore();
+const notificationStore = useNotificationStore();
+const { t } = useI18n();
+
+const show = defineModel('show', {
+    type: Boolean,
+    required: true,
+});
+
+const props = defineProps<{
+    selectedCostume: Character | null;
+    toggleMod: (mod: BD2Mod) => void;
+}>();
+
+const modsStore = useModsStore();
+const charactersStore = useCharactersStore();
+
+// Only dating mods for the selected character's dating_id.
+const installedMods = computed<BD2Mod[]>(() => {
+    if (!props.selectedCostume?.dating_id) return [];
+    const datingId = props.selectedCostume.dating_id;
+    return sortModsByPath(
+        modsStore.mods.filter(mod =>
+            mod.modType?.type === 'Dating' &&
+            'id' in mod.modType &&
+            mod.modType.id === datingId
+        )
+    );
+});
+
+const enabledModsCount = computed(() =>
+    installedMods.value.filter(mod => mod.enabled).length
+);
+
+// Labelled affection entries (from dating.json). Each entry can have multiple
+// mods created for it (same as Dating mods), so it becomes its own group with
+// its own header and the full list of matching Scene-typed mods beneath it.
+// Entries with no installed mod keep a single greyed "not installed" row.
+interface AffectionGroup {
+    label: string;
+    id: string;
+    mods: BD2Mod[];
+    enabledCount: number;
+}
+
+const affectionGroups = computed<AffectionGroup[]>(() => {
+    if (!props.selectedCostume?.dating_id) return [];
+    const affection = charactersStore.getAffection(props.selectedCostume.dating_id);
+    return affection.map(entry => {
+        const mods = sortModsByPath(
+            modsStore.mods.filter(m =>
+                m.modType?.type === 'Scene' &&
+                'id' in m.modType &&
+                m.modType.id === entry.id
+            )
+        );
+        return {
+            label: entry.label,
+            id: entry.id,
+            mods,
+            enabledCount: mods.filter(m => m.enabled).length,
+        };
+    });
+});
+
+// Only groups that actually have at least one installed mod are rendered.
+const installedAffectionGroups = computed(() =>
+    affectionGroups.value.filter(g => g.mods.length > 0)
+);
+
+async function openPreviewMod(mod: BD2Mod) {
+    modsStore.previewMod(mod.name).then(() => {
+        loggingStore.logDebug("Mod previewed successfully:", mod.name);
+    }).catch((error) => {
+        const errorMsg = getErrorMessage(t, error);
+        notificationStore.add({
+            severity: "error",
+            closable: true,
+            title: t("modsTab.errors.modPreview.title"),
+            message: errorMsg,
+            duration: 5000
+        });
+        loggingStore.logError("Error previewing mod:", error);
+    });
+}
+
+const imageUrl = computed(() => {
+    if (!props.selectedCostume) return "#"
+    const ids = Array.isArray(props.selectedCostume.id)
+        ? props.selectedCostume.id.join(',')
+        : props.selectedCostume.id
+    return convertFileSrc(`standing/${ids}`, "bd2assets")
+})
+
+const lang = useLang()
+
+const charName = computed(() => {
+    if (!props.selectedCostume) return
+    return getCharName(props.selectedCostume, lang.value)
+})
+</script>
+
+<template>
+    <Modal v-model:show="show" class="w-[50vw] max-h-[85vh]" @close="() => show = false">
+        <template #footer>
+            <div class="flex p-3 justify-end items-center w-full border-t border-border-default">
+                <Button variant="default" :label="$t('common.actions.close')" @click="show = false" />
+            </div>
+        </template>
+        <template #header></template>
+
+        <div v-if="selectedCostume" class="flex flex-col min-h-0 text-text-primary overflow-hidden">
+            <div class="flex items-stretch border-b border-border-default shrink-0">
+                <Image :src="imageUrl"
+                    class="w-40 h-40 object-cover shrink-0 border-r border-border-default aspect-square"
+                    skeleton
+                    error-src="characters/standing/placeholder_character.png"
+                    error-class="bg-text-primary" />
+
+                <div class="flex-1 px-4 py-3 flex flex-col">
+                    <div class="flex items-start justify-between gap-2">
+                        <div>
+                            <div class="flex items-baseline gap-2">
+                                <h3 class="font-semibold text-base text-text-primary">{{ charName?.character }}</h3>
+                                <span class="text-sm text-text-secondary">{{ charName?.costume }}</span>
+                            </div>
+                            <div class="flex flex-col items-start gap-3 mt-1 text-xs text-text-secondary">
+                                <span class="flex items-center gap-1">
+                                    <Tag class="w-4 h-4"/>
+                                    {{ Array.isArray(selectedCostume.id) ? selectedCostume.id.join(', ') : selectedCostume.id }}
+                                </span>
+                                <span v-if="selectedCostume.release_date" class="flex items-center gap-1">
+                                    <Calendar class="w-4 h-4" />
+                                    {{ new Date(selectedCostume.release_date).toLocaleDateString() }}
+                                </span>
+                            </div>
+                        </div>
+                        <button @click="show = false"
+                            class="text-text-secondary cursor-pointer hover:text-text-primary transition-colors p-1 rounded-sm hover:bg-state-hover"
+                            :aria-label="$t('common.actions.close')">
+                            <X class="w-4 h-4" />
+                        </button>
+                    </div>
+
+                    <div class="flex gap-5 mt-3 flex-1 items-end">
+                        <div>
+                            <p class="text-base font-semibold leading-none">{{ enabledModsCount }}</p>
+                            <p class="text-xs text-text-secondary mt-0.5">{{ $t('charactersTab.characterModal.enabledMods') }}</p>
+                        </div>
+                        <div>
+                            <p class="text-base font-semibold leading-none">{{ installedMods.length }}</p>
+                            <p class="text-xs text-text-secondary mt-0.5">{{ $t('charactersTab.characterModal.totalMods') }}</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="flex flex-col min-h-0 flex-1 overflow-y-auto h-100">
+                <div v-if="installedMods.length === 0 && installedAffectionGroups.length === 0" class="text-center py-12 px-4 text-text-secondary">
+                    <p class="text-sm font-medium mb-1">{{ $t('charactersTab.characterModal.noModsFound.title') }}</p>
+                    <p class="text-xs text-text-secondary">{{ $t('charactersTab.characterModal.noModsFound.description') }}</p>
+                </div>
+                <template v-else>
+                    <!-- Dating mods section -->
+                    <template v-if="installedMods.length > 0">
+                        <div class="flex items-center justify-between px-4 py-2 bg-surface-dialog border-b border-border-default top-0 z-10">
+                            <span class="text-xs font-medium text-text-secondary uppercase tracking-wide">
+                                {{ $t('charactersTab.modTypes.dating') }}
+                            </span>
+                            <span class="text-xs text-text-secondary">{{ enabledModsCount }}/{{ installedMods.length }}</span>
+                        </div>
+                        <label v-for="mod in installedMods" :key="mod.name"
+                            class="flex items-center gap-3 px-4 py-2.5 border-b border-border-default cursor-pointer hover:bg-state-hover transition-colors"
+                            :class="{ 'bg-surface-dialog': !mod.enabled }">
+                            <Checkbox :model-value="mod.enabled" @update:model-value="toggleMod(mod)" class="shrink-0" />
+                            <button @click.stop="openPreviewMod(mod)" :aria-label="$t('charactersTab.characterModal.previewMod')">
+                                <Eye class="w-6 h-6 cursor-pointer hover:text-text-primary! transition-colors active:scale-95 text-text-secondary" />
+                            </button>
+                            <div class="flex-1 min-w-0">
+                                <p class="text-sm truncate" :class="mod.enabled ? 'text-text-primary' : 'text-text-secondary'">{{ mod.name }}</p>
+                                <p v-if="mod.author" class="text-xs text-text-secondary mt-0.5">{{ mod.author }}</p>
+                            </div>
+                        </label>
+                    </template>
+
+                    <!-- Affection mods section: one group (with its own header)
+                         per labelled affection entry from dating.json. -->
+                    <template v-for="group in installedAffectionGroups" :key="group.id">
+                        <div class="flex items-center justify-between px-4 py-2 bg-surface-dialog border-b border-border-default top-0 z-10">
+                            <span class="text-xs font-medium text-text-secondary uppercase tracking-wide">
+                                {{ $t('datingTab.affection.label', { label: group.label }) }}
+                            </span>
+                            <span class="text-xs text-text-secondary">{{ group.enabledCount }}/{{ group.mods.length }}</span>
+                        </div>
+                        <label v-for="mod in group.mods" :key="mod.name"
+                            class="flex items-center gap-3 px-4 py-2.5 border-b border-border-default cursor-pointer hover:bg-state-hover transition-colors"
+                            :class="{ 'bg-surface-dialog': !mod.enabled }">
+                            <Checkbox :model-value="mod.enabled" @update:model-value="toggleMod(mod)" class="shrink-0" />
+                            <button @click.stop="openPreviewMod(mod)" :aria-label="$t('charactersTab.characterModal.previewMod')">
+                                <Eye class="w-6 h-6 cursor-pointer hover:text-text-primary! transition-colors active:scale-95 text-text-secondary" />
+                            </button>
+                            <div class="flex-1 min-w-0">
+                                <p class="text-sm truncate" :class="mod.enabled ? 'text-text-primary' : 'text-text-secondary'">{{ mod.name }}</p>
+                                <p v-if="mod.author" class="text-xs text-text-secondary mt-0.5">{{ mod.author }}</p>
+                            </div>
+                        </label>
+                    </template>
+                </template>
+            </div>
+        </div>
+    </Modal>
+</template>

--- a/src/pages/mods/ModsHeader.vue
+++ b/src/pages/mods/ModsHeader.vue
@@ -19,14 +19,14 @@ interface Filters {
 }
 
 const filters = defineModel<Filters>("filters", {
-    default: {
+    default: () => ({
         searchQuery: '',
         modTypes: [],
         onlyEnabled: false,
         onlyDisabled: false,
         onlyConflicts: false,
         onlyErrors: false,
-    }
+    })
 })
 
 const modTypes = ["Cutscene", "Standing", "Scene", "Dating", "NPC", "Minigame"];

--- a/src/router.ts
+++ b/src/router.ts
@@ -6,6 +6,7 @@ import ProfilesTab from './pages/profiles/ProfilesTab.vue'
 import BDXTab from './pages/browndustx/BDXTab.vue'
 import ScenesTab from './pages/scenes/ScenesTab.vue'
 import NpcsTab from './pages/npcs/NpcsTab.vue'
+import DatingTab from './pages/dating/DatingTab.vue'
 
 const routes = [
     {
@@ -31,6 +32,11 @@ const routes = [
         name: 'npcs',
         path: '/npcs',
         component: NpcsTab
+    },
+    {
+        name: 'dating',
+        path: '/dating',
+        component: DatingTab
     },
     {
         name: 'profiles',

--- a/src/stores/characters.ts
+++ b/src/stores/characters.ts
@@ -28,9 +28,30 @@ export interface Character {
     element: "dark" | "light" | "water" | "fire" | "wind"
 }
 
+/** A single labelled affection entry within a dating definition. */
+export interface AffectionEntry {
+    /** Label from dating.txt, e.g. "1", "2-1", "2-2". */
+    label: string;
+    /** Scene mod id (matches modType.id for a Scene-typed mod). */
+    id: string;
+}
+
+/** A dating character entry from dating.json. */
+export interface DatingDefinition {
+    dating_id: string;
+    costume_id: string;
+    character: string;
+    costume: string;
+    affection: AffectionEntry[];
+}
+
 interface CharactersJson {
     characters: Character[];
     dating: DatingMap;
+}
+
+interface DatingJson {
+    dating: DatingDefinition[];
 }
 
 type DatingMap = Record<string, string>;
@@ -50,6 +71,10 @@ export const useCharactersStore = defineStore("characters", () => {
     const datingMap = shallowRef<DatingMap>({});
     const charactersMap = shallowRef<Record<string, Character>>({});
     const datingToCharacterMap = shallowRef<Record<string, Character>>({});
+
+    // Dating affection data from dating.json
+    const datingDefinitions = shallowRef<DatingDefinition[]>([]);
+    const datingDefinitionsMap = shallowRef<Record<string, DatingDefinition>>({});
 
     const groupedCharacters = computed<Record<string, Character[]>>(() => {
         return characters.value.reduce((acc, c) => {
@@ -112,6 +137,29 @@ export const useCharactersStore = defineStore("characters", () => {
         }, `getCharacterByNpcId(${npcId})`, false);
     }
 
+    function updateDating(data: DatingJson) {
+        datingDefinitions.value = data.dating ?? [];
+        datingDefinitionsMap.value = Object.fromEntries(
+            (data.dating ?? []).map(d => [d.dating_id, d])
+        );
+    }
+
+    /** Returns the labelled affection list for a dating_id, or []. */
+    function getAffection(datingId: string): AffectionEntry[] {
+        return datingDefinitionsMap.value[datingId]?.affection ?? [];
+    }
+
+    async function loadDating() {
+        try {
+            const data = await invoke<DatingJson>("get_dating");
+            updateDating(data);
+            if (import.meta.env.DEV)
+                console.info("Dating definitions loaded:", datingDefinitions.value.length);
+        } catch (error) {
+            console.error("Failed to load dating definitions:", error);
+        }
+    }
+
     async function loadCharacters() {
         try {
             const data = await invoke<CharactersJson>("get_characters");
@@ -125,11 +173,14 @@ export const useCharactersStore = defineStore("characters", () => {
 
     return {
         characters: readonly(characters),
+        datingDefinitions: readonly(datingDefinitions),
         groupedCharacters: readonly(groupedCharacters),
         loadCharacters,
+        loadDating,
         getCharacterById,
         getCharacterByDatingId,
         getCharacterIdByDatingId,
-        getCharacterByNpcId
+        getCharacterByNpcId,
+        getAffection,
     };
 });

--- a/src/utils/sortMods.ts
+++ b/src/utils/sortMods.ts
@@ -1,0 +1,37 @@
+import type { BD2Mod } from '../stores/mods';
+
+/** Last path segment (mod folder name), ignoring trailing separators. */
+function basename(p: string): string {
+    const parts = p.split(/[\\/]/).filter(Boolean);
+    return parts.length ? parts[parts.length - 1] : p;
+}
+
+/** True when the character is a plain latin A-Z / a-z letter. */
+function startsWithAToZ(name: string): boolean {
+    return /^[A-Za-z]/.test(name);
+}
+
+/**
+ * Returns a new array of mods sorted A-Z by their folder path on disk.
+ * Non-mutating. Uses numeric-aware locale compare so that, e.g.,
+ * `mod2` sorts before `mod10` rather than between `mod1` and `mod2`.
+ *
+ * Mods whose folder name does NOT start with an A-z letter (e.g. names
+ * beginning with a number, symbol, or non-latin character) are pushed
+ * BEHIND the A-z ones, then sorted amongst themselves.
+ *
+ * Used by the per-character mod modal and the NPC mod modal so that
+ * installed mods are listed in stable alphabetical order regardless of
+ * the order they come back from the backend.
+ */
+export function sortModsByPath(mods: readonly BD2Mod[]): BD2Mod[] {
+    return [...mods].sort((a, b) => {
+        const aAlpha = startsWithAToZ(basename(a.path));
+        const bAlpha = startsWithAToZ(basename(b.path));
+        if (aAlpha !== bAlpha) {
+            // A-z names first, everything else behind.
+            return aAlpha ? -1 : 1;
+        }
+        return a.path.localeCompare(b.path, undefined, { numeric: true, sensitivity: 'base' });
+    });
+}


### PR DESCRIPTION
Adds a dedicated Dating page mirroring the Characters tab layout, backed by a new dating.json data file seeded into appdata (auto-synced from characters.json). 
Shows dating mods per character with labelled affection scenes. 
Adds get_dating command, get_dating_path, dating sidebar button, and dating route. 
Includes sortMods.ts helper used by the dating modal.