### PR TITLE
feat: Sort Mod Name column by displayed name

### DIFF
--- a/src/pages/mods/Modlist.vue
+++ b/src/pages/mods/Modlist.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { h, ref, computed, onActivated, onDeactivated, nextTick } from 'vue'
+import { h, ref, computed, onActivated, onDeactivated, nextTick, watch } from 'vue'
 import { useVirtualizer } from '@tanstack/vue-virtual'
 import { BD2ModExtended } from '../../stores/mods'
 import {
@@ -131,6 +131,13 @@ const columns = [
             ])
         },
         header: () => h('span', { class: 'flex text-text-primary items-center' }, t('modsTab.modlist.header.modName')),
+        sortingFn: (rowA, rowB) => {
+            const useDisplayName = preferencesStore.modNameDisplay === "short"
+            const nameA = useDisplayName ? rowA.original.displayName : rowA.original.name
+            const nameB = useDisplayName ? rowB.original.displayName : rowB.original.name
+            return nameA.localeCompare(nameB, undefined, { sensitivity: 'base' })
+        },
+        sortDescFirst: false,
         size: 300
     }),
     columnHelper.accessor('modType', {
@@ -339,6 +346,15 @@ const table = useVueTable({
 })
 
 const rows = computed(() => table.getRowModel().rows)
+
+// Re-apply current sorting when mod-name display preference changes so
+// the list re-orders to match what the column shows.
+watch(() => preferencesStore.modNameDisplay, () => {
+    if (sorting.value.some(sort => sort.id === 'name')) {
+        table.setSorting([...sorting.value])
+    }
+})
+
 
 const selectedMods = computed(() => {
     return rows.value

--- a/src/pages/mods/ModsHeader.vue
+++ b/src/pages/mods/ModsHeader.vue
@@ -19,14 +19,14 @@ interface Filters {
 }
 
 const filters = defineModel<Filters>("filters", {
-    default: {
+    default: () => ({
         searchQuery: '',
         modTypes: [],
         onlyEnabled: false,
         onlyDisabled: false,
         onlyConflicts: false,
         onlyErrors: false,
-    }
+    })
 })
 
 const modTypes = ["Cutscene", "Standing", "Scene", "Dating", "NPC", "Minigame"];


### PR DESCRIPTION
In current version Mod Name is sort though subfolder Name even "Mod Name" is choose in Mod Name Column setting, which is odd cuz this make the sorting function seems "wrong", this feat fix/edits that

This version Mod Name is sorted from A-z, special symbol shows after